### PR TITLE
make db accessable from outside for core models

### DIFF
--- a/k8s/postgresql/postgresql.service.yaml
+++ b/k8s/postgresql/postgresql.service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: db
 spec:
-  type: ClusterIP
+  type: LoadBalancer
   ports:
   - port: 5432
     targetPort: 5432


### PR DESCRIPTION
External access for goose and jet cli.